### PR TITLE
Fix VideoBackgroundShader crash: "Unknown uniform: texelSize"

### DIFF
--- a/.changeset/fix-video-shader-texelsize-uniform.md
+++ b/.changeset/fix-video-shader-texelsize-uniform.md
@@ -1,0 +1,7 @@
+---
+'@holocron.so/vite': patch
+---
+
+Fix `VideoBackgroundShader` crashing with "Unknown uniform: texelSize" on some GPUs.
+
+The splat program was being assigned the `texelSize` uniform even though its fragment shader (`SPLAT_FRAG`) only reads `vUv`. On drivers that strip inactive uniforms during linking, `texelSize` is culled from the splat program and the cached-uniform lookup throws. The splat program is now excluded from the `texelSize` setup loop, since it never uses it.

--- a/vite/src/components/markdown/video-background-shader.tsx
+++ b/vite/src/components/markdown/video-background-shader.tsx
@@ -713,7 +713,10 @@ function createVideoShaderEngine(container: HTMLElement, config: Required<Omit<V
 
   const texelX = 1 / simW
   const texelY = 1 / simH
-  for (const p of [advectionP, divergenceP, curlP, vorticityP, pressureP, gradientSubtractP, splatP]) {
+  // NB: splatP is excluded — SPLAT_FRAG only reads vUv, so the GLSL linker
+  // strips texelSize as an inactive uniform on some drivers, which would make
+  // loc('texelSize') throw ("Unknown uniform: texelSize").
+  for (const p of [advectionP, divergenceP, curlP, vorticityP, pressureP, gradientSubtractP]) {
     gl.useProgram(p.program)
     gl.uniform2f(p.loc('texelSize'), texelX, texelY)
   }


### PR DESCRIPTION
## Problem

The landing-page hero (`VideoBackgroundShader`) throws on mount for some users:

```
Application Error
Unknown uniform: texelSize
```

The error originates from the cached-uniform guard in `createGpuProgram().loc()` (`vite/src/components/markdown/video-background-shader.tsx`).

## Root cause

The splat program is built from `FLUID_VERTEX` + `SPLAT_FRAG`. `FLUID_VERTEX` declares `uniform vec2 texelSize` but uses it **only** to compute the `vL/vR/vT/vB` varyings. `SPLAT_FRAG` reads **only `vUv`** — it never touches those varyings, so they're dead in the splat program, which makes `texelSize` a dead uniform.

GLSL linkers may strip inactive uniforms. On GPU/driver backends that do (e.g. ANGLE over D3D11/Metal, many native GL drivers), `texelSize` is culled from the splat program's active-uniform list, so the `for (… splatP) { … p.loc('texelSize') }` setup loop throws `Unknown uniform: texelSize`. The program itself links fine — the error is the post-link lookup, not a compile/link failure.

This is why it reproduces on real GPUs but not on software rasterizers (SwiftShader), which don't strip it — and why it can ship unnoticed.

## Fix

Exclude `splatP` from the `texelSize` setup loop, since the splat shader never uses it. Every remaining program in the loop genuinely consumes `texelSize`. One-line change (plus a comment and a changeset).

## Verification

Verified the hero renders with the WebGL engine fully initializing and **no** `Unknown uniform` / shader-compile / link errors in the console, across initial load and reloads.